### PR TITLE
#12 fix for decimal setting comment true/false

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "filesize.useDecimal": {
           "type": "boolean",
           "default": false,
-          "description": "Defaults to false, using IEC's representation. Set to false to get SI representation."
+          "description": "Defaults to false, using IEC's representation. Set to true to get SI representation."
         },
         "filesize.use24HourFormat": {
           "type": "boolean",


### PR DESCRIPTION
Like we spoke about on issue #12 I adjusted the "filesize.useDecimal" setting comment to state true rather than false for the second sentence.