### PR TITLE
Add option to show the gzip size in the status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This package has two user configurable settings:
 - `useDecimal`: set to `true` if you want your size data to be displayed according to the [SI unit system](https://en.wikipedia.org/wiki/International_System_of_Units) or leave it at `false` to use [IEC's](https://en.wikipedia.org/wiki/Binary_prefix) format (default).
 - `use24HourFormat`: set to `true` to use the 24-hour clock, set to `false` to use the 12-hour clock. Default is `true`.
 - `showGzip`: set to `true` to show calculated gzip size in the detailed info view. Default is `true`.
+- `showGzipInStatusBar`: set to `true` to show calculated gzip size in the status bar. Default is `false`.
 
 ## Contributing
 

--- a/extension.js
+++ b/extension.js
@@ -12,7 +12,8 @@ function updateConfig() {
   config = {
     useDecimal: configuration.get('useDecimal'),
     use24HourFormat: configuration.get('use24HourFormat'),
-    showGzip: configuration.get('showGzip')
+    showGzip: configuration.get('showGzip'),
+    showGzipInStatusBar: configuration.get('showGzipInStatusBar')
   };
   updateStatusBarItem();
   return config;
@@ -22,6 +23,10 @@ function showStatusBarItem(newInfo) {
   info = fzCalculator.addPrettySize(newInfo, config);
   if (info && info.prettySize) {
     statusBarItem.text = info.prettySize;
+    if (config.showGzipInStatusBar) {
+      info = fzCalculator.addGzipSize(info, config);
+      statusBarItem.text += ` | ${info.gzipSize}`
+    }
     statusBarItem.show();
   }
 }

--- a/extension.js
+++ b/extension.js
@@ -24,8 +24,9 @@ function showStatusBarItem(newInfo) {
   if (info && info.prettySize) {
     statusBarItem.text = info.prettySize;
     if (config.showGzipInStatusBar) {
+      statusBarItem.text = `Min: ${info.prettySize}`;
       info = fzCalculator.addGzipSize(info, config);
-      statusBarItem.text += ` | ${info.gzipSize}`
+      statusBarItem.text += ` | Gzip: ${info.gzipSize}`
     }
     statusBarItem.show();
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,12 @@
           "type": "boolean",
           "default": true,
           "description": "Defaults to true, whether to show gzip size in detailed view or not."
-        }
+        },
+        "filesize.showGzipInStatusBar": {
+					"type": "boolean",
+					"default": false,
+					"description": "Defaults to false, whether to show gzip size in the status bar."
+				}
       }
     }
   },


### PR DESCRIPTION
This pull request adds a configuration option to show the gzip size in the status bar aside the normal size.

Exemple: 
`1.65 kB | 392 bytes`