### PR TITLE
docs: clarify and clean up settings section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ To open the detailed view for the current file in focus you can just click at th
 
 This package has the following user-configurable settings:
 
-- `useDecimal`: set to `true` if you want your size data to be displayed according to the [SI unit system](https://en.wikipedia.org/wiki/International_System_of_Units) or leave it at `false` to use [IEC's](https://en.wikipedia.org/wiki/Binary_prefix) format (default).
-- `use24HourFormat`: set to `true` to use the 24-hour clock, set to `false` to use the 12-hour clock. Default is `true`.
+- `displayInfoOnTheRightSideOfStatusBar`: set to `true` to show the status bar info on the right side. Default is `false` (left side).
+- `showBrotli`: set to `true` to show calculated brotli compressed size in the detailed info view. Default is `false`.
 - `showGzip`: set to `true` to show calculated gzip size in the detailed info view. Default is `true`.
 - `showGzipInStatusBar`: set to `true` to show calculated gzip size in the status bar. Default is `false`.
-- `showBrotli`: set to `true` to show calculated brotli compressed size in the detailed info view. Default is `false`.
-- `displayInfoOnTheRightSideOfStatusBar`: set to `true` to show the status bar info on the right side. Default is `false` (left side).
+- `use24HourFormat`: set to `true` to use the 24-hour clock, set to `false` to use the 12-hour clock. Default is `true`.
+- `useDecimal`: set to `true` if you want your size data to be displayed according to the [SI unit system](https://en.wikipedia.org/wiki/International_System_of_Units) or leave it at `false` to use [IEC's](https://en.wikipedia.org/wiki/Binary_prefix) format (default).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To open the detailed view for the current file in focus you can just click at th
 
 ## Settings
 
-This package has two user configurable settings:
+This package has the following user-configurable settings:
 
 - `useDecimal`: set to `true` if you want your size data to be displayed according to the [SI unit system](https://en.wikipedia.org/wiki/International_System_of_Units) or leave it at `false` to use [IEC's](https://en.wikipedia.org/wiki/Binary_prefix) format (default).
 - `use24HourFormat`: set to `true` to use the 24-hour clock, set to `false` to use the 12-hour clock. Default is `true`.

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ To open the detailed view for the current file in focus you can just click at th
 
 This package has the following user-configurable settings:
 
-- `displayInfoOnTheRightSideOfStatusBar`: set to `true` to show the status bar info on the right side. Default is `false` (left side).
-- `showBrotli`: set to `true` to show calculated brotli compressed size in the detailed info view. Default is `false`.
-- `showGzip`: set to `true` to show calculated gzip size in the detailed info view. Default is `true`.
-- `showGzipInStatusBar`: set to `true` to show calculated gzip size in the status bar. Default is `false`.
-- `use24HourFormat`: set to `true` to use the 24-hour clock, set to `false` to use the 12-hour clock. Default is `true`.
-- `useDecimal`: set to `true` if you want your size data to be displayed according to the [SI unit system](https://en.wikipedia.org/wiki/International_System_of_Units) or leave it at `false` to use [IEC's](https://en.wikipedia.org/wiki/Binary_prefix) format (default).
+- `displayInfoOnTheRightSideOfStatusBar`: Show the status bar info on the right side instead of the left. (Default: `false`)
+- `showBrotli`: Show the calculated brotli-compressed size in the detailed info view. (Default: `false`)
+- `showGzip`: Show the calculated gzip-compressed size in the detailed info view. (Default: `true`)
+- `showGzipInStatusBar`: Show the calculated gzip-compressed size directly in the status bar. (Default: `false`)
+- `use24HourFormat`: Use the 24-hour clock format for time display; set to `false` for 12-hour format. (Default: `true`)
+- `useDecimal`: Display file sizes using the [SI unit system](https://en.wikipedia.org/wiki/International_System_of_Units); set to `false` to use [IEC's](https://en.wikipedia.org/wiki/Binary_prefix) format. (Default: `false`)
 
 ## Contributing
 


### PR DESCRIPTION
Tidied up the settings list in the README for better clarity and consistency. Each option now has a clearer description and the defaults are easier to spot. No code changes—just making the docs easier to read!

Changes made:
- Alphabetized the list of user-configurable settings.
- Rewrote each setting’s description for clarity and consistency.
- Clearly stated default values in parentheses at the end of each item.
- Made the language more concise and user-friendly.